### PR TITLE
add AutoBindEnv option and unit tests

### DIFF
--- a/config.go
+++ b/config.go
@@ -67,6 +67,7 @@ type Config struct {
 	Debug      bool
 
 	FromConfig bool
+	AutoBindEnv bool
 
 	Name             interface{}
 	Environment      interface{}
@@ -104,7 +105,7 @@ func DryRun(reason string, args ...interface{}) bool {
 func (s *Config) read() {
 	// This should make it safe to rerun a few times
 	if !s.initConfigDone {
-		settings.ReadConfig(s.File, s.Dir, s.EnvPrefix, s.OnlyUseDir)
+		settings.ReadConfig(s.File, s.Dir, s.EnvPrefix, s.OnlyUseDir, s.AutoBindEnv)
 		s.initConfigDone = true
 	}
 }

--- a/config_read_auto-bind-env_test.go
+++ b/config_read_auto-bind-env_test.go
@@ -1,0 +1,45 @@
+package config_test
+
+import (
+	. "github.com/mexisme/go-config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"os"
+)
+
+var _ = Describe("config", func() {
+	Describe("from a config file", func() {
+		It("is not to bind environment variables automatically after reading and initialising with AutoBindEnv off", func() {
+			valInternal := ""
+			os.Setenv("TEST_FOO_TEST_BAR", "test-bar-value-from-env-var")
+
+			Init(Config{
+				File:       "config-auto-bind-env",
+				Dir:        "fixtures",
+				FromConfig: true,
+			})
+
+			ApplyWith("test_foo.test_bar", func(val interface{}) {
+				valInternal = val.(string)
+			})
+			Expect(valInternal).To(Equal("test-bar-value"))
+		})
+
+		It("is to bind environment variables automatically after reading and initialising with AutoBindEnv on", func() {
+			valInternal := ""
+			os.Setenv("TEST_FOO_TEST_BAR", "test-bar-value-from-env-var")
+
+			Init(Config{
+				File:       "config-auto-bind-env",
+				Dir:        "fixtures",
+				FromConfig: true,
+				AutoBindEnv: true,
+			})
+
+			ApplyWith("test_foo.test_bar", func(val interface{}) {
+				valInternal = val.(string)
+			})
+			Expect(valInternal).To(Equal("test-bar-value-from-env-var"))
+		})
+	})
+})

--- a/fixtures/config-auto-bind-env.toml
+++ b/fixtures/config-auto-bind-env.toml
@@ -1,0 +1,4 @@
+debug = true
+
+[test_foo]
+test_bar = "test-bar-value"

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -29,7 +29,7 @@ const (
 // `envPrefix` allows you to add a Viper "EnvPrefix" to config env-vars
 // `useOnlyDir` disables looking for a config file in "$HOME" or "." directories.
 // TODO:  list config items
-func ReadConfig(configFile, configDir, envPrefix string, onlyUseDir bool) {
+func ReadConfig(configFile, configDir, envPrefix string, onlyUseDir bool, autoBindEnv bool) {
 	// This means any "." chars in a FQ config name will be replaced with "_"
 	// e.g. "sentry.dsn" --> "$SENTRY_DSN" instead of "$SENTRY.DSN" (which won't work)
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
@@ -55,7 +55,11 @@ func ReadConfig(configFile, configDir, envPrefix string, onlyUseDir bool) {
 
 		if err := viper.ReadInConfig(); err == nil {
 			log.WithFields(log.Fields{"config_file": viper.ConfigFileUsed()}).Debug("Using file")
-
+			if autoBindEnv {
+				for _, key := range viper.AllKeys() {
+					viper.BindEnv(key)
+				}
+			}
 		} else {
 			log.WithFields(log.Fields{"config_file": viper.ConfigFileUsed()}).Error(err)
 		}


### PR DESCRIPTION
- Add a `AutoBindEnv` option. When it is on, all the keys will be bound to env, which means they can be overriden by system environment variables.

- unit tests